### PR TITLE
[RFC] Improve compatibility with legacy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "keywords": ["cache"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
-        "react/promise": "~2.0"
+        "php": ">=5.3.0",
+        "react/promise": "~2.0|~1.1"
     },
     "autoload": {
         "psr-4": { "React\\Cache\\": "src\\" }


### PR DESCRIPTION
Because *why not*… :-)

Now more seriously: This project is a low level lib that is used as a building block for quite a few higher level abstractions on top of it. As such, compatibility (even with significantly outdated versions) is a major concern to me.

Note that I'm not suggesting putting *significant amount* of work into this. The patch is already here and, personally, I see *literally no harm* in supporting this.

Also note that I'm not suggesting we need to keep support indefinitely. Should this ever turn out to be a burden in the future, e.g. because we actually *require* any new language features or some external lib, then I'm all for dropping support again.