### PR TITLE
Fix autoload paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
         "react/promise": "~2.0|~1.1"
     },
     "autoload": {
-        "psr-4": { "React\\Cache\\": "src\\" }
+        "psr-4": { "React\\Cache\\": "src/" }
     },
     "autoload-dev": {
-        "psr-4": { "React\\Tests\\Cache\\": "tests\\" }
+        "psr-4": { "React\\Tests\\Cache\\": "tests/" }
     }
 }


### PR DESCRIPTION
Appending a backspace to the autoload path never really made any sense, but Composer has always ignored trailing (back)slashes. However, this may (and in fact does) cause issues in other tools that rely on a stricter interpretation according to [Composer's documentation](https://getcomposer.org/doc/04-schema.md#psr-4). For example, the following does *not* work due to the trailing backslash:

```php
$loader = require __DIR__ . '/vendor/autoload.php';

$loader->addPsr4('React\\Tests\\Cache\\', 'tests\\');
```