### PR TITLE
Add PHPUnit 4.8 to require-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - composer install --prefer-source --no-interaction
   
 script:
-  - phpunit --coverage-text
+  - ./vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,8 @@
     },
     "autoload-dev": {
         "psr-4": { "React\\Tests\\Cache\\": "tests/" }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.8"
     }
 }


### PR DESCRIPTION
As mentioned in reactphp/react#354

Added phpunit 4.8 to require-dev section of composer.json
Modified travisci config to use local phpunit.