### PR TITLE
Cache miss resolves with null value

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This example fetches the value of the key `foo` and passes it to the
 `var_dump` function. You can use any of the composition provided by
 [promises](https://github.com/reactphp/promise).
 
-If the key `foo` does not exist, the promise will be rejected.
+If the key `foo` does not exist, the promise will be fulfilled with `null` as value.
 
 #### set()
 
@@ -91,14 +91,20 @@ example of that:
 ```php
 $cache
     ->get('foo')
-    ->then(null, 'getFooFromDb')
+    ->then(function ($result) {
+        if ($result === null) {
+            return getFooFromDb();
+        }
+        
+        return $result;
+    })
     ->then('var_dump');
 ```
 
-First an attempt is made to retrieve the value of `foo`. A promise rejection
-handler of the function `getFooFromDb` is registered. `getFooFromDb` is a
-function (can be any PHP callable) that will be called if the key does not
-exist in the cache.
+First an attempt is made to retrieve the value of `foo`. A callback function is 
+registered that will call `getFooFromDb` when the resulting value is null. 
+`getFooFromDb` is a function (can be any PHP callable) that will be called if the 
+key does not exist in the cache.
 
 `getFooFromDb` can handle the missing key by returning a promise for the
 actual value from the database (or any other data source). As a result, this
@@ -112,7 +118,13 @@ cache after fetching it from the data source.
 ```php
 $cache
     ->get('foo')
-    ->then(null, array($this, 'getAndCacheFooFromDb'))
+    ->then(function ($result) {
+        if ($result === null) {
+            return $this->getAndCacheFooFromDb();
+        }
+        
+        return $result;
+    })
     ->then('var_dump');
 
 public function getAndCacheFooFromDb()

--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -11,7 +11,7 @@ class ArrayCache implements CacheInterface
     public function get($key)
     {
         if (!isset($this->data[$key])) {
-            return Promise\reject();
+            return Promise\resolve(null);
         }
 
         return Promise\resolve($this->data[$key]);

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -8,7 +8,7 @@ interface CacheInterface
 {
     /**
      * Retrieve an item from the cache, resolves with its value on
-     * success or rejects when no item can be found.
+     * success or null when no item can be found.
      *
      * @param string $key
      * @return PromiseInterface

--- a/tests/ArrayCacheTest.php
+++ b/tests/ArrayCacheTest.php
@@ -14,13 +14,19 @@ class ArrayCacheTest extends TestCase
     }
 
     /** @test */
-    public function getShouldRejectPromiseForNonExistentKey()
+    public function getShouldResolvePromiseWithNullForNonExistentKey()
     {
+        $success = $this->createCallableMock();
+        $success
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(null);
+
         $this->cache
             ->get('foo')
             ->then(
-                $this->expectCallableNever(),
-                $this->expectCallableOnce()
+                $success,
+                $this->expectCallableNever()
             );
     }
 
@@ -53,8 +59,8 @@ class ArrayCacheTest extends TestCase
         $this->cache
             ->get('foo')
             ->then(
-                $this->expectCallableNever(),
-                $this->expectCallableOnce()
+                $this->expectCallableOnce(),
+                $this->expectCallableNever()
             );
     }
 }


### PR DESCRIPTION
As discussed in #13, a failing `get` should resolve with `null` instead of rejecting.

To do:
* [X] Updated interface
* [x] Updated ArrayCache
* [x] Updated Readme

Implements / closes #13 