### PR TITLE
Add $default to return instead of null on cache miss for get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ provide alternate implementations.
 
 #### get()
 
+The `get(string $key, mixed $default = null): PromiseInterfae` method can be used to
+retrieve an item from the cache.
+
+This method will resolve with the cached value on success or with the
+given `$default` value when no item can be found or when an error occurs.
+
 ```php
 $cache
     ->get('foo')
@@ -46,9 +52,6 @@ $cache
 This example fetches the value of the key `foo` and passes it to the
 `var_dump` function. You can use any of the composition provided by
 [promises](https://github.com/reactphp/promise).
-
-If the key `foo` does not exist, the promise will be fulfilled with `null` as value. On 
-any error it will also resolve with `null`.
 
 #### set()
 

--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -41,10 +41,10 @@ class ArrayCache implements CacheInterface
         $this->limit = $limit;
     }
 
-    public function get($key)
+    public function get($key, $default = null)
     {
-        if (!isset($this->data[$key])) {
-            return Promise\resolve();
+        if (!array_key_exists($key, $this->data)) {
+            return Promise\resolve($default);
         }
 
         // remove and append to end of array to keep track of LRU info

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -7,13 +7,26 @@ use React\Promise\PromiseInterface;
 interface CacheInterface
 {
     /**
-     * Retrieve an item from the cache, resolves with its value on
-     * success or null when no item can be found or when an error occurs.
+     * Retrieves an item from the cache.
+     *
+     * This method will resolve with the cached value on success or with the
+     * given `$default` value when no item can be found or when an error occurs.
+     *
+     * ```php
+     * $cache
+     *     ->get('foo')
+     *     ->then('var_dump');
+     * ```
+     *
+     * This example fetches the value of the key `foo` and passes it to the
+     * `var_dump` function. You can use any of the composition provided by
+     * [promises](https://github.com/reactphp/promise).
      *
      * @param string $key
+     * @param mixed  $default Default value to return for cache miss or null if not given.
      * @return PromiseInterface
      */
-    public function get($key);
+    public function get($key, $default = null);
 
     /**
      * Store an item in the cache, returns a promise which resolves to true on success or

--- a/tests/ArrayCacheTest.php
+++ b/tests/ArrayCacheTest.php
@@ -83,6 +83,28 @@ class ArrayCacheTest extends TestCase
             );
     }
 
+    public function testGetWillResolveWithNullForCacheMiss()
+    {
+        $this->cache = new ArrayCache();
+
+        $this->cache->get('foo')->then($this->expectCallableOnceWith(null));
+    }
+
+    public function testGetWillResolveWithDefaultValueForCacheMiss()
+    {
+        $this->cache = new ArrayCache();
+
+        $this->cache->get('foo', 'bar')->then($this->expectCallableOnceWith('bar'));
+    }
+
+    public function testGetWillResolveWithExplicitNullValueForCacheHit()
+    {
+        $this->cache = new ArrayCache();
+
+        $this->cache->set('foo', null);
+        $this->cache->get('foo', 'bar')->then($this->expectCallableOnceWith(null));
+    }
+
     public function testLimitSizeToZeroDoesNotStoreAnyData()
     {
         $this->cache = new ArrayCache(0);


### PR DESCRIPTION
Resolves / closes #24 
Builds on top of #26 