### PR TITLE
Add cache expiration support (TTL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,13 @@ This example fetches the value of the key `foo` and passes it to the
 `var_dump` function. You can use any of the composition provided by
 [promises](https://github.com/reactphp/promise).
 
+If the key `foo` does not exist or when the TTL has passed, the promise will 
+be fulfilled with `null` as value. On any error it will also resolve with `null`.
+
 #### set()
 
 ```php
-$cache->set('foo', 'bar');
+$cache->set('foo', 'bar', 60);
 ```
 
 This example eventually sets the value of the key `foo` to `bar`. If it

--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ provide alternate implementations.
 
 #### get()
 
-The `get(string $key, mixed $default = null): PromiseInterfae` method can be used to
+The `get(string $key, mixed $default = null): PromiseInterface` method can be used to
 retrieve an item from the cache.
 
 This method will resolve with the cached value on success or with the
 given `$default` value when no item can be found or when an error occurs.
+Similarly, an expired cache item (once the time-to-live is expired) is
+considered a cache miss.
 
 ```php
 $cache
@@ -53,20 +55,27 @@ This example fetches the value of the key `foo` and passes it to the
 `var_dump` function. You can use any of the composition provided by
 [promises](https://github.com/reactphp/promise).
 
-If the key `foo` does not exist or when the TTL has passed, the promise will 
-be fulfilled with `null` as value. On any error it will also resolve with `null`.
-
 #### set()
+
+The `set(string $key, mixed $value, ?float $ttl = null): PromiseInterface` method can be used to
+store an item in the cache.
+
+This method will resolve with `true` on success or `false` when an error
+occurs. If the cache implementation has to go over the network to store
+it, it may take a while.
+
+The optional `$ttl` parameter sets the maximum time-to-live in seconds
+for this cache item. If this parameter is omitted (or `null`), the item
+will stay in the cache for as long as the underlying implementation
+supports. Trying to access an expired cache item results in a cache miss,
+see also [`get()`](#get).
 
 ```php
 $cache->set('foo', 'bar', 60);
 ```
 
 This example eventually sets the value of the key `foo` to `bar`. If it
-already exists, it is overridden. To provide guarantees as to when the cache
-value is set a promise is returned. The promise will fulfill with `true` on success 
-or `false` on error. If the cache implementation has to go over the network to store 
-it, it may take a while.
+already exists, it is overridden.
 
 #### remove()
 

--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -3,11 +3,18 @@
 namespace React\Cache;
 
 use React\Promise;
+use SplPriorityQueue;
 
 class ArrayCache implements CacheInterface
 {
     private $limit;
     private $data = array();
+    private $expires = array();
+
+    /**
+     * @var SplPriorityQueue
+     */
+    private $expiresQueue;
 
     /**
      * The `ArrayCache` provides an in-memory implementation of the [`CacheInterface`](#cacheinterface).
@@ -39,10 +46,16 @@ class ArrayCache implements CacheInterface
     public function __construct($limit = null)
     {
         $this->limit = $limit;
+        $this->expiresQueue = new SplPriorityQueue();
+        $this->expiresQueue->setExtractFlags(SplPriorityQueue::EXTR_BOTH);
     }
 
     public function get($key, $default = null)
     {
+        if (array_key_exists($key, $this->expires)) {
+            $this->garbageCollection();
+        }
+
         if (!array_key_exists($key, $this->data)) {
             return Promise\resolve($default);
         }
@@ -51,28 +64,55 @@ class ArrayCache implements CacheInterface
         $value = $this->data[$key];
         unset($this->data[$key]);
         $this->data[$key] = $value;
-
         return Promise\resolve($value);
     }
 
-    public function set($key, $value)
+    public function set($key, $value, $ttl = null)
     {
+        $expires = null;
+
+        if (is_int($ttl)) {
+            $this->expires[$key] = microtime(true) + $ttl;
+            $this->expiresQueue->insert($key, 0 - $this->expires[$key]);
+        }
+
         // unset before setting to ensure this entry will be added to end of array
         unset($this->data[$key]);
         $this->data[$key] = $value;
 
-        // ensure size limit is not exceeded or remove first entry from array
-        if ($this->limit !== null && count($this->data) > $this->limit) {
-            reset($this->data);
-            unset($this->data[key($this->data)]);
-        }
+        $this->garbageCollection();
 
         return Promise\resolve(true);
     }
 
     public function remove($key)
     {
-        unset($this->data[$key]);
+        unset($this->data[$key], $this->expires[$key]);
+        $this->garbageCollection();
         return Promise\resolve(true);
+    }
+
+    private function garbageCollection()
+    {
+        // ensure size limit is not exceeded or remove first entry from array
+        while ($this->limit !== null && count($this->data) > $this->limit) {
+            reset($this->data);
+            unset($this->data[key($this->data)]);
+        }
+
+        if ($this->expiresQueue->count() === 0) {
+            return;
+        }
+
+        $this->expiresQueue->rewind();
+        do {
+            $run = false;
+            $item = $this->expiresQueue->current();
+            if ((int)substr((string)$item['priority'], 1) <= microtime(true)) {
+                $this->expiresQueue->extract();
+                $run = true;
+                unset($this->data[$item['data']], $this->expires[$item['data']]);
+            }
+        } while ($run && $this->expiresQueue->count() > 0);
     }
 }

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -11,6 +11,8 @@ interface CacheInterface
      *
      * This method will resolve with the cached value on success or with the
      * given `$default` value when no item can be found or when an error occurs.
+     * Similarly, an expired cache item (once the time-to-live is expired) is
+     * considered a cache miss.
      *
      * ```php
      * $cache
@@ -29,13 +31,29 @@ interface CacheInterface
     public function get($key, $default = null);
 
     /**
-     * Store an item in the cache, returns a promise which resolves to true on success or
-     * false on error.
+     * Stores an item in the cache.
+     *
+     * This method will resolve with `true` on success or `false` when an error
+     * occurs. If the cache implementation has to go over the network to store
+     * it, it may take a while.
+     *
+     * The optional `$ttl` parameter sets the maximum time-to-live in seconds
+     * for this cache item. If this parameter is omitted (or `null`), the item
+     * will stay in the cache for as long as the underlying implementation
+     * supports. Trying to access an expired cache item results in a cache miss,
+     * see also [`get()`](#get).
+     *
+     * ```php
+     * $cache->set('foo', 'bar', 60);
+     * ```
+     *
+     * This example eventually sets the value of the key `foo` to `bar`. If it
+     * already exists, it is overridden.
      *
      * @param string $key
-     * @param mixed $value
-     * @param float|null $ttl
-     * @return PromiseInterface Returns a promise which resolves to true on success of false on error
+     * @param mixed  $value
+     * @param ?float $ttl
+     * @return PromiseInterface Returns a promise which resolves to `true` on success or `false` on error
      */
     public function set($key, $value, $ttl = null);
 

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -34,9 +34,10 @@ interface CacheInterface
      *
      * @param string $key
      * @param mixed $value
+     * @param float|null $ttl
      * @return PromiseInterface Returns a promise which resolves to true on success of false on error
      */
-    public function set($key, $value);
+    public function set($key, $value, $ttl = null);
 
     /**
      * Remove an item from the cache, returns a promise which resolves to true on success or

--- a/tests/ArrayCacheTest.php
+++ b/tests/ArrayCacheTest.php
@@ -152,4 +152,47 @@ class ArrayCacheTest extends TestCase
         $this->cache->get('bar')->then($this->expectCallableOnceWith(null));
         $this->cache->get('baz')->then($this->expectCallableOnceWith('3'));
     }
+
+    /** @test */
+    public function getWithinTtl()
+    {
+        $this->cache
+            ->set('foo', 'bar', 100);
+
+
+        $success = $this->createCallableMock();
+        $success
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with('bar');
+
+        $this->cache
+            ->get('foo')
+            ->then(
+                $success,
+                $this->expectCallableNever()
+            );
+    }
+
+    /** @test */
+    public function getAfterTtl()
+    {
+        $this->cache
+            ->set('foo', 'bar', 1);
+
+        sleep(2);
+
+        $success = $this->createCallableMock();
+        $success
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(null);
+
+        $this->cache
+            ->get('foo')
+            ->then(
+                $success,
+                $this->expectCallableNever()
+            );
+    }
 }


### PR DESCRIPTION
This PR adds support for cache expiry (TTL). This is a new feature for most consumers, but this is also a BC break because it adds a new parameter to the `CacheInterface::set($name, $value, $ttl = null)` signature.

As its name implies, the `ArrayCache` uses an array to store the optional TTL and will yield a cache miss when a cache item is expired.

Builds on top of #28, thank you @WyriHaximus for the initial version! I've squashed the original version to a single commit to preserve authorship. Unlike the initial version, this updated version uses an array for significantly faster operation (heavily inspired by https://github.com/reactphp/event-loop/pull/164).

Supersedes / closes #28
Resolves / closes #11 