### PR TITLE
Rename remove() to delete() for consistency with PSR-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ provide alternate implementations.
   * [CacheInterface](#cacheinterface)
     * [get()](#get)
     * [set()](#set)
-    * [remove()](#remove)
+    * [delete()](#delete)
   * [ArrayCache](#arraycache)
 * [Common usage](#common-usage)
   * [Fallback get](#fallback-get)
@@ -77,15 +77,22 @@ $cache->set('foo', 'bar', 60);
 This example eventually sets the value of the key `foo` to `bar`. If it
 already exists, it is overridden.
 
-#### remove()
+#### delete()
+
+Deletes an item from the cache.
+
+This method will resolve with `true` on success or `false` when an error
+occurs. When no item for `$key` is found in the cache, it also resolves
+to `true`. If the cache implementation has to go over the network to
+delete it, it may take a while.
 
 ```php
-$cache->remove('foo');
+$cache->delete('foo');
 ```
 
-This example eventually removes the key `foo` from the cache. As with `set`,
-this may not happen instantly and a promise is returned to provide guarantees whether 
-or not the item has been removed from cache.
+This example eventually deletes the key `foo` from the cache. As with
+`set()`, this may not happen instantly and a promise is returned to
+provide guarantees whether or not the item has been removed from cache.
 
 ### ArrayCache
 

--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -93,7 +93,7 @@ class ArrayCache implements CacheInterface
         return Promise\resolve(true);
     }
 
-    public function remove($key)
+    public function delete($key)
     {
         unset($this->data[$key], $this->expires[$key]);
 

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -58,12 +58,23 @@ interface CacheInterface
     public function set($key, $value, $ttl = null);
 
     /**
-     * Remove an item from the cache, returns a promise which resolves to true on success or
-     * false on error. When the $key isn't found in the cache it also
-     * resolves true.
+     * Deletes an item from the cache.
+     *
+     * This method will resolve with `true` on success or `false` when an error
+     * occurs. When no item for `$key` is found in the cache, it also resolves
+     * to `true`. If the cache implementation has to go over the network to
+     * delete it, it may take a while.
+     *
+     * ```php
+     * $cache->delete('foo');
+     * ```
+     *
+     * This example eventually deletes the key `foo` from the cache. As with
+     * `set()`, this may not happen instantly and a promise is returned to
+     * provide guarantees whether or not the item has been removed from cache.
      *
      * @param string $key
-     * @return PromiseInterface Returns a promise which resolves to true on success of false on error
+     * @return PromiseInterface Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function remove($key);
+    public function delete($key);
 }

--- a/tests/ArrayCacheTest.php
+++ b/tests/ArrayCacheTest.php
@@ -59,13 +59,13 @@ class ArrayCacheTest extends TestCase
     }
 
     /** @test */
-    public function removeShouldRemoveKey()
+    public function deleteShouldDeleteKey()
     {
         $this->cache
             ->set('foo', 'bar');
 
-        $removePromise = $this->cache
-            ->remove('foo');
+        $deletePromise = $this->cache
+            ->delete('foo');
 
         $mock = $this->createCallableMock();
         $mock
@@ -73,7 +73,7 @@ class ArrayCacheTest extends TestCase
             ->method('__invoke')
             ->with($this->identicalTo(true));
 
-        $removePromise->then($mock);
+        $deletePromise->then($mock);
 
         $this->cache
             ->get('foo')


### PR DESCRIPTION
This simple PR renames the existing `remove()` method to `delete()` for consistency with PSR-6 and PSR-16. It also adds some documentation to be in line with #16 and #29, but the behavior is otherwise left unchanged.

```php
// old
$cache->remove('foo');

// new
$cache->delete('foo');
```

Empirical evidence suggests that this method is rarely used and this release includes a number of BC breaks that aim at making this interface act more like a standard PSR-16 cache, so I figured it makes sense to rename this as part of this release.