### PR TITLE
Use high-resolution timer for cache TTL on PHP 7.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 # - hhvm # requires legacy phpunit & ignore errors, see below
 
 # lock distro so new future defaults will not break the build
@@ -24,6 +27,6 @@ sudo: false
 
 install:
   - composer install --no-interaction
-  
+
 script:
   - ./vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ $cache->set('foo', 'bar', 60);
 This example eventually sets the value of the key `foo` to `bar`. If it
 already exists, it is overridden.
 
+This interface suggests that cache implementations SHOULD use a monotonic
+time source if available. Given that a monotonic time source is only
+available as of PHP 7.3 by default, cache implementations MAY fall back
+to using wall-clock time.
+While this does not affect many common use cases, this is an important
+distinction for programs that rely on a high time precision or on systems
+that are subject to discontinuous time adjustments (time jumps).
+This means that if you store a cache item with a TTL of 30s and then
+adjust your system time forward by 20s, the cache item SHOULD still
+expire in 30s.
+
 #### delete()
 
 The `delete(string $key): PromiseInterface<bool>` method can be used to
@@ -229,6 +240,16 @@ $cache->set('foo', '1');
 $cache->set('bar', '2');
 $cache->set('baz', '3');
 ```
+
+This cache implementation is known to rely on wall-clock time to schedule
+future cache expiration times when using any version before PHP 7.3,
+because a monotonic time source is only available as of PHP 7.3 (`hrtime()`).
+While this does not affect many common use cases, this is an important
+distinction for programs that rely on a high time precision or on systems
+that are subject to discontinuous time adjustments (time jumps).
+This means that if you store a cache item with a TTL of 30s on PHP < 7.3
+and then adjust your system time forward by 20s, the cache item may
+expire in 10s. See also [`set()`](#set) for more details.
 
 ## Common usage
 

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -50,6 +50,17 @@ interface CacheInterface
      * This example eventually sets the value of the key `foo` to `bar`. If it
      * already exists, it is overridden.
      *
+     * This interface suggests that cache implementations SHOULD use a monotonic
+     * time source if available. Given that a monotonic time source is only
+     * available as of PHP 7.3 by default, cache implementations MAY fall back
+     * to using wall-clock time.
+     * While this does not affect many common use cases, this is an important
+     * distinction for programs that rely on a high time precision or on systems
+     * that are subject to discontinuous time adjustments (time jumps).
+     * This means that if you store a cache item with a TTL of 30s and then
+     * adjust your system time forward by 20s, the cache item SHOULD still
+     * expire in 30s.
+     *
      * @param string $key
      * @param mixed  $value
      * @param ?float $ttl


### PR DESCRIPTION
This project suggests that cache implementations SHOULD use a
monotonic time source if available. Given that a monotonic time source is
only available as of PHP 7.3 by default, event loop implementations MAY
fall back to using wall-clock time. http://php.net/manual/en/function.hrtime.php

Builds on top of https://github.com/reactphp/event-loop/pull/182 and https://github.com/reactphp/event-loop/pull/130