### PR TITLE
Allow legacy HHVM to fail in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 5.5
   - 5.6
   - 7
-  - hhvm
+# - hhvm # requires legacy phpunit & ignore errors, see below
 
 # lock distro so new future defaults will not break the build
 dist: trusty
@@ -15,6 +15,10 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: hhvm
+      install: composer require phpunit/phpunit:^5 --dev --no-interaction
+  allow_failures:
+    - php: hhvm
 
 sudo: false
 


### PR DESCRIPTION
HHVM decided to drop support for PHP, so it's questionable if supporting
it in the future is worth the effort.
https://hhvm.com/blog/2019/02/11/hhvm-4.0.0.html

This PR does not aim to discuss how useful HHVM is and whether or not we
want to continue supporting it. It only aims to make the test output
consistent by ignoring legacy HHVM fails in the build matrix to not mark
the complete test suite as failed.

Refs https://github.com/clue/php-socket-raw/pull/42 and others.