### PR TITLE
[RFC] Use arrays instead of iterable for multiple cache items

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,27 +116,30 @@ provide guarantees whether or not the item has been removed from cache.
 
 #### getMultiple()
 
-The `getMultiple(iterable $keys, mixed $default = null): PromiseInterface<iterable>` method can be used to
+The `getMultiple(string[] $keys, mixed $default = null): PromiseInterface<array>` method can be used to
 retrieve multiple cache items by their unique keys.
 
-This method will resolve with the list of cached value on success or with the
-given `$default` value when no item can be found or when an error occurs.
+This method will resolve with an array of cached values on success or with the
+given `$default` value when an item can not be found or when an error occurs.
 Similarly, an expired cache item (once the time-to-live is expired) is
 considered a cache miss.
 
 ```php
-$cache
-    ->getMultiple(array('foo', 'bar'))
-    ->then('var_dump');
+$cache->getMultiple(array('name', 'age'))->then(function (array $values) {
+    $name = $values['name'] ?? 'User';
+    $age = $values['age'] ?? 'n/a';
+
+    echo $name . ' is ' . $age . PHP_EOL;
+});
 ```
 
-This example fetches the list of value for `foo` and `bar` keys and passes it to the
-`var_dump` function. You can use any of the composition provided by
-[promises](https://github.com/reactphp/promise).
+This example fetches the cache items for the `name` and `age` keys and
+prints some example output. You can use any of the composition provided
+by [promises](https://github.com/reactphp/promise).
 
 #### setMultiple()
 
-The `setMultiple(iterable $values, ?float $ttl = null): PromiseInterface<bool>` method can be used to
+The `setMultiple(array $values, ?float $ttl = null): PromiseInterface<bool>` method can be used to
 persist a set of key => value pairs in the cache, with an optional TTL.
 
 This method will resolve with `true` on success or `false` when an error
@@ -158,7 +161,7 @@ and the key `bar` to `2`. If some of the keys already exist, they are overridden
 
 #### deleteMultiple()
 
-The `setMultiple(iterable $keys): PromiseInterface<bool>` method can be used to
+The `setMultiple(string[] $keys): PromiseInterface<bool>` method can be used to
 delete multiple cache items in a single operation.
 
 This method will resolve with `true` on success or `false` when an error

--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -115,7 +115,7 @@ class ArrayCache implements CacheInterface
         return Promise\resolve(true);
     }
 
-    public function getMultiple($keys, $default = null)
+    public function getMultiple(array $keys, $default = null)
     {
         $values = array();
 
@@ -126,7 +126,7 @@ class ArrayCache implements CacheInterface
         return Promise\all($values);
     }
 
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple(array $values, $ttl = null)
     {
         foreach ($values as $key => $value) {
             $this->set($key, $value, $ttl);
@@ -135,7 +135,7 @@ class ArrayCache implements CacheInterface
         return Promise\resolve(true);
     }
 
-    public function deleteMultiple($keys)
+    public function deleteMultiple(array $keys)
     {
         foreach ($keys as $key) {
             unset($this->data[$key], $this->expires[$key]);

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -92,26 +92,29 @@ interface CacheInterface
     /**
      * Retrieves multiple cache items by their unique keys.
      *
-     * This method will resolve with the list of cached value on success or with the
-     * given `$default` value when no item can be found or when an error occurs.
+     * This method will resolve with an array of cached values on success or with the
+     * given `$default` value when an item can not be found or when an error occurs.
      * Similarly, an expired cache item (once the time-to-live is expired) is
      * considered a cache miss.
      *
      * ```php
-     * $cache
-     *     ->getMultiple(array('foo', 'bar'))
-     *     ->then('var_dump');
+     * $cache->getMultiple(array('name', 'age'))->then(function (array $values) {
+     *     $name = $values['name'] ?? 'User';
+     *     $age = $values['age'] ?? 'n/a';
+     *
+     *     echo $name . ' is ' . $age . PHP_EOL;
+     * });
      * ```
      *
-     * This example fetches the list of value for `foo` and `bar` keys and passes it to the
-     * `var_dump` function. You can use any of the composition provided by
-     * [promises](https://github.com/reactphp/promise).
+     * This example fetches the cache items for the `name` and `age` keys and
+     * prints some example output. You can use any of the composition provided
+     * by [promises](https://github.com/reactphp/promise).
      *
-     * @param iterable $keys    A list of keys that can obtained in a single operation.
-     * @param mixed    $default Default value to return for keys that do not exist.
-     * @return PromiseInterface
+     * @param string[] $keys A list of keys that can obtained in a single operation.
+     * @param mixed $default Default value to return for keys that do not exist.
+     * @return PromiseInterface<array> Returns a promise which resolves to an `array` of cached values
      */
-    public function getMultiple($keys, $default = null);
+    public function getMultiple(array $keys, $default = null);
 
     /**
      * Persists a set of key => value pairs in the cache, with an optional TTL.
@@ -133,24 +136,24 @@ interface CacheInterface
      * This example eventually sets the list of values - the key `foo` to 1 value
      * and the key `bar` to 2. If some of the keys already exist, they are overridden.
      *
-     * @param iterable $values A list of key => value pairs for a multiple-set operation.
-     * @param ?float   $ttl    Optional. The TTL value of this item.
-     * @return bool PromiseInterface Returns a promise which resolves to `true` on success or `false` on error
+     * @param array  $values A list of key => value pairs for a multiple-set operation.
+     * @param ?float $ttl    Optional. The TTL value of this item.
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function setMultiple($values, $ttl = null);
+    public function setMultiple(array $values, $ttl = null);
 
     /**
      * Deletes multiple cache items in a single operation.
      *
-     * @param iterable $keys A list of string-based keys to be deleted.
-     * @return bool PromiseInterface Returns a promise which resolves to `true` on success or `false` on error
+     * @param string[] $keys A list of string-based keys to be deleted.
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function deleteMultiple($keys);
+    public function deleteMultiple(array $keys);
 
     /**
      * Wipes clean the entire cache.
      *
-     * @return bool PromiseInterface Returns a promise which resolves to `true` on success or `false` on error
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
     public function clear();
 
@@ -177,7 +180,7 @@ interface CacheInterface
      * another script can remove it making the state of your app out of date.
      *
      * @param string $key The cache item key.
-     * @return PromiseInterface Returns a promise which resolves to `true` on success or `false` on error
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
     public function has($key);
 }


### PR DESCRIPTION
Using arrays makes the API slightly stricter and allows consumers to
consistently rely on associative arrays for getMultiple() and
setMultiple().

I'm filing this as an RFC to discuss whether `array` type declaration provide more value over the current `iterable` type. From a practical perspective this doesn't make much of a difference because our existing `ArrayCache` implementation already uses `array` anyway. By adding this to the interface documentation, we can make the API more consistent. In particular, see the updated documentation for the `getMultiple()` call to see why I think this could be useful.

The `iterable` type was added as part of #32 by @krlv in an attempt to mimic PSR-16. While I can see some use in supporting `iterable` in a blocking PSR-16 implementation (such as cache warmup with a very large number of keys), I'm not sure this really applies to this async API.