### PR TITLE
Update to require PHP 7.1+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,6 @@ jobs:
           - 7.3
           - 7.2
           - 7.1
-          - 7.0
-          - 5.6
-          - 5.5
-          - 5.4
-          - 5.3
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
@@ -36,19 +31,3 @@ jobs:
         if: ${{ matrix.php >= 7.3 }}
       - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
-
-  PHPUnit-hhvm:
-    name: PHPUnit (HHVM)
-    runs-on: ubuntu-22.04
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
-      - name: Run hhvm composer.phar require react/promise:^2 # downgrade Promise for HHVM
-        uses: docker://hhvm/hhvm:3.30-lts-latest
-        with:
-          args: hhvm composer.phar require react/promise:^2
-      - name: Run hhvm vendor/bin/phpunit
-        uses: docker://hhvm/hhvm:3.30-lts-latest
-        with:
-          args: hhvm vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -351,9 +351,8 @@ composer require react/cache:^3@dev
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
-HHVM.
-It's *highly recommended to use PHP 7+* for this project.
+extensions and supports running on PHP 7.1 through current PHP 8+.
+It's *highly recommended to use the latest supported PHP version* for this project.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Similarly, an expired cache item (once the time-to-live is expired) is
 considered a cache miss.
 
 ```php
-$cache->getMultiple(array('name', 'age'))->then(function (array $values) {
+$cache->getMultiple(['name', 'age'])->then(function (array $values) {
     $name = $values['name'] ?? 'User';
     $age = $values['age'] ?? 'n/a';
 
@@ -170,7 +170,7 @@ supports. Trying to access an expired cache items results in a cache miss,
 see also [`getMultiple()`](#getmultiple).
 
 ```php
-$cache->setMultiple(array('foo' => 1, 'bar' => 2), 60);
+$cache->setMultiple(['foo' => 1, 'bar' => 2], 60);
 ```
 
 This example eventually sets the list of values - the key `foo` to `1` value 
@@ -187,7 +187,7 @@ to `true`. If the cache implementation has to go over the network to
 delete it, it may take a while.
 
 ```php
-$cache->deleteMultiple(array('foo', 'bar, 'baz'));
+$cache->deleteMultiple(['foo', 'bar, 'baz']);
 ```
 
 This example eventually deletes keys `foo`, `bar` and `baz` from the cache. 
@@ -322,7 +322,7 @@ public function getAndCacheFooFromDb()
 {
     return $this->db
         ->get('foo')
-        ->then(array($this, 'cacheFooFromDb'));
+        ->then([$this, 'cacheFooFromDb']);
 }
 
 public function cacheFooFromDb($foo)

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.1",
         "react/promise": "^3.0 || ^2.0 || ^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+        "phpunit/phpunit": "^9.6 || ^5.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "react/promise": "^3.0 || ^2.0 || ^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^5.7"
+        "phpunit/phpunit": "^9.6 || ^7.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -2,7 +2,7 @@
 
 <!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -2,7 +2,7 @@
 
 <!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>

--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -2,14 +2,14 @@
 
 namespace React\Cache;
 
-use React\Promise;
-use React\Promise\PromiseInterface;
+use function React\Promise\all;
+use function React\Promise\resolve;
 
 class ArrayCache implements CacheInterface
 {
     private $limit;
-    private $data = array();
-    private $expires = array();
+    private $data = [];
+    private $expires = [];
     private $supportsHighResolution;
 
     /**
@@ -65,7 +65,7 @@ class ArrayCache implements CacheInterface
         }
 
         if (!\array_key_exists($key, $this->data)) {
-            return Promise\resolve($default);
+            return resolve($default);
         }
 
         // remove and append to end of array to keep track of LRU info
@@ -73,7 +73,7 @@ class ArrayCache implements CacheInterface
         unset($this->data[$key]);
         $this->data[$key] = $value;
 
-        return Promise\resolve($value);
+        return resolve($value);
     }
 
     public function set($key, $value, $ttl = null)
@@ -105,25 +105,25 @@ class ArrayCache implements CacheInterface
             unset($this->data[$key], $this->expires[$key]);
         }
 
-        return Promise\resolve(true);
+        return resolve(true);
     }
 
     public function delete($key)
     {
         unset($this->data[$key], $this->expires[$key]);
 
-        return Promise\resolve(true);
+        return resolve(true);
     }
 
     public function getMultiple(array $keys, $default = null)
     {
-        $values = array();
+        $values = [];
 
         foreach ($keys as $key) {
             $values[$key] = $this->get($key, $default);
         }
 
-        return Promise\all($values);
+        return all($values);
     }
 
     public function setMultiple(array $values, $ttl = null)
@@ -132,7 +132,7 @@ class ArrayCache implements CacheInterface
             $this->set($key, $value, $ttl);
         }
 
-        return Promise\resolve(true);
+        return resolve(true);
     }
 
     public function deleteMultiple(array $keys)
@@ -141,15 +141,15 @@ class ArrayCache implements CacheInterface
             unset($this->data[$key], $this->expires[$key]);
         }
 
-        return Promise\resolve(true);
+        return resolve(true);
     }
 
     public function clear()
     {
-        $this->data = array();
-        $this->expires = array();
+        $this->data = [];
+        $this->expires = [];
 
-        return Promise\resolve(true);
+        return resolve(true);
     }
 
     public function has($key)
@@ -160,7 +160,7 @@ class ArrayCache implements CacheInterface
         }
 
         if (!\array_key_exists($key, $this->data)) {
-            return Promise\resolve(false);
+            return resolve(false);
         }
 
         // remove and append to end of array to keep track of LRU info
@@ -168,7 +168,7 @@ class ArrayCache implements CacheInterface
         unset($this->data[$key]);
         $this->data[$key] = $value;
 
-        return Promise\resolve(true);
+        return resolve(true);
     }
 
     /**

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -106,7 +106,7 @@ interface CacheInterface
      * considered a cache miss.
      *
      * ```php
-     * $cache->getMultiple(array('name', 'age'))->then(function (array $values) {
+     * $cache->getMultiple(['name', 'age'])->then(function (array $values) {
      *     $name = $values['name'] ?? 'User';
      *     $age = $values['age'] ?? 'n/a';
      *
@@ -138,7 +138,7 @@ interface CacheInterface
      * see also [`get()`](#get).
      *
      * ```php
-     * $cache->setMultiple(array('foo' => 1, 'bar' => 2), 60);
+     * $cache->setMultiple(['foo' => 1, 'bar' => 2], 60);
      * ```
      *
      * This example eventually sets the list of values - the key `foo` to 1 value

--- a/tests/ArrayCacheTest.php
+++ b/tests/ArrayCacheTest.php
@@ -203,27 +203,27 @@ class ArrayCacheTest extends TestCase
         $this->cache->set('foo', '1');
 
         $this->cache
-            ->getMultiple(array('foo', 'bar'), 'baz')
-            ->then($this->expectCallableOnceWith(array('foo' => '1', 'bar' => 'baz')));
+            ->getMultiple(['foo', 'bar'], 'baz')
+            ->then($this->expectCallableOnceWith(['foo' => '1', 'bar' => 'baz']));
     }
 
     public function testSetMultiple()
     {
         $this->cache = new ArrayCache();
-        $this->cache->setMultiple(array('foo' => '1', 'bar' => '2'), 10);
+        $this->cache->setMultiple(['foo' => '1', 'bar' => '2'], 10);
 
         $this->cache
-            ->getMultiple(array('foo', 'bar'))
-            ->then($this->expectCallableOnceWith(array('foo' => '1', 'bar' => '2')));
+            ->getMultiple(['foo', 'bar'])
+            ->then($this->expectCallableOnceWith(['foo' => '1', 'bar' => '2']));
     }
 
     public function testDeleteMultiple()
     {
         $this->cache = new ArrayCache();
-        $this->cache->setMultiple(array('foo' => 1, 'bar' => 2, 'baz' => 3));
+        $this->cache->setMultiple(['foo' => 1, 'bar' => 2, 'baz' => 3]);
 
         $this->cache
-            ->deleteMultiple(array('foo', 'baz'))
+            ->deleteMultiple(['foo', 'baz'])
             ->then($this->expectCallableOnceWith(true));
 
         $this->cache
@@ -242,7 +242,7 @@ class ArrayCacheTest extends TestCase
     public function testClearShouldClearCache()
     {
         $this->cache = new ArrayCache();
-        $this->cache->setMultiple(array('foo' => 1, 'bar' => 2, 'baz' => 3));
+        $this->cache->setMultiple(['foo' => 1, 'bar' => 2, 'baz' => 3]);
 
         $this->cache->clear();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -49,12 +49,13 @@ class TestCase extends BaseTestCase
 
     protected function createCallableMock()
     {
-        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+        $builder = $this->getMockBuilder(\stdClass::class);
+        if (method_exists($builder, 'addMethods')) {
             // PHPUnit 9+
-            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+            return $builder->addMethods(['__invoke'])->getMock();
         } else {
-            // legacy PHPUnit 4 - PHPUnit 9
-            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+            // legacy PHPUnit
+            return $builder->setMethods(['__invoke'])->getMock();
         }
     }
 }


### PR DESCRIPTION
This changeset updates the project to require PHP 7.1+ and drop legacy PHP < 7.1 and HHVM as discussed in #56. I'm marking this as a BC break for anybody still stuck on very old PHP versions, but there's little chance this will affect any current projects otherwise.

This PR aims to contain the minimal changeset to update the PHP version requirement only. Follow-up PRs will update our APIs to leverage newer language features.

Builds on top of #55 and others