### PR TITLE
Update to require Promise v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "react/promise": "^3.0 || ^2.0 || ^1.1"
+        "react/promise": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^7.5"


### PR DESCRIPTION
This trivial changeset updates this project to require Promise v3 as discussed in #56. Legacy Promise v2 and v1 will be deprecated in the future and Promise v3 is the way to go.

I'm planning to introduce PHPStan in a follow-up PR which will take advantage of Promise v3 template types (https://github.com/reactphp/promise/pull/247).

Once merged, we should apply similar changes to all our upcoming v3 components.

Builds on top of #58 and #39