### PR TITLE
Support `iterable` type for all methods working with multiple keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ provide guarantees whether or not the item has been removed from cache.
 
 #### getMultiple()
 
-The `getMultiple(string[] $keys, mixed $default = null): PromiseInterface<array>` method can be used to
+The `getMultiple(iterable<string> $keys, mixed $default = null): PromiseInterface<iterable<string,mixed>>` method can be used to
 retrieve multiple cache items by their unique keys.
 
 This method will resolve with an array of cached values on success or with the
@@ -142,9 +142,10 @@ Similarly, an expired cache item (once the time-to-live is expired) is
 considered a cache miss.
 
 ```php
-$cache->getMultiple(['name', 'age'])->then(function (array $values): void {
-    $name = $values['name'] ?? 'User';
-    $age = $values['age'] ?? 'n/a';
+$cache->getMultiple(['name', 'age'])->then(function (iterable $values): void {
+    $array = is_array($values) ? $values : iterator_to_array($values);
+    $name = $array['name'] ?? 'User';
+    $age = $array['age'] ?? 'n/a';
 
     echo $name . ' is ' . $age . PHP_EOL;
 });
@@ -156,7 +157,7 @@ by [promises](https://github.com/reactphp/promise).
 
 #### setMultiple()
 
-The `setMultiple(array $values, ?float $ttl = null): PromiseInterface<bool>` method can be used to
+The `setMultiple(iterable<string,mixed> $values, ?float $ttl = null): PromiseInterface<bool>` method can be used to
 persist a set of key => value pairs in the cache, with an optional TTL.
 
 This method will resolve with `true` on success or `false` when an error
@@ -178,7 +179,7 @@ and the key `bar` to `2`. If some of the keys already exist, they are overridden
 
 #### deleteMultiple()
 
-The `setMultiple(string[] $keys): PromiseInterface<bool>` method can be used to
+The `setMultiple(iterable<string> $keys): PromiseInterface<bool>` method can be used to
 delete multiple cache items in a single operation.
 
 This method will resolve with `true` on success or `false` when an error

--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -123,7 +123,7 @@ class ArrayCache implements CacheInterface
         return resolve(true);
     }
 
-    public function getMultiple(array $keys, $default = null): PromiseInterface
+    public function getMultiple(iterable $keys, $default = null): PromiseInterface
     {
         $values = [];
 
@@ -135,7 +135,7 @@ class ArrayCache implements CacheInterface
         return all($values);
     }
 
-    public function setMultiple(array $values, ?float $ttl = null): PromiseInterface
+    public function setMultiple(iterable $values, ?float $ttl = null): PromiseInterface
     {
         foreach ($values as $key => $value) {
             $this->set($key, $value, $ttl);
@@ -144,7 +144,7 @@ class ArrayCache implements CacheInterface
         return resolve(true);
     }
 
-    public function deleteMultiple(array $keys): PromiseInterface
+    public function deleteMultiple(iterable $keys): PromiseInterface
     {
         foreach ($keys as $key) {
             unset($this->data[$key], $this->expires[$key]);

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -106,9 +106,10 @@ interface CacheInterface
      * considered a cache miss.
      *
      * ```php
-     * $cache->getMultiple(['name', 'age'])->then(function (array $values): void {
-     *     $name = $values['name'] ?? 'User';
-     *     $age = $values['age'] ?? 'n/a';
+     * $cache->getMultiple(['name', 'age'])->then(function (iterable $values): void {
+     *     $array = is_array($values) ? $values : iterator_to_array($values);
+     *     $name = $array['name'] ?? 'User';
+     *     $age = $array['age'] ?? 'n/a';
      *
      *     echo $name . ' is ' . $age . PHP_EOL;
      * });
@@ -118,11 +119,11 @@ interface CacheInterface
      * prints some example output. You can use any of the composition provided
      * by [promises](https://github.com/reactphp/promise).
      *
-     * @param string[] $keys A list of keys that can obtained in a single operation.
+     * @param iterable<string> $keys A list of keys that can obtained in a single operation.
      * @param mixed $default Default value to return for keys that do not exist.
-     * @return PromiseInterface<array<string,mixed>> Returns a promise which resolves to an `array` of cached values
+     * @return PromiseInterface<iterable<string,mixed>> Returns a promise which resolves to an `array` of cached values
      */
-    public function getMultiple(array $keys, $default = null): PromiseInterface;
+    public function getMultiple(iterable $keys, $default = null): PromiseInterface;
 
     /**
      * Persists a set of key => value pairs in the cache, with an optional TTL.
@@ -144,19 +145,19 @@ interface CacheInterface
      * This example eventually sets the list of values - the key `foo` to 1 value
      * and the key `bar` to 2. If some of the keys already exist, they are overridden.
      *
-     * @param array<string,mixed> $values A list of key => value pairs for a multiple-set operation.
+     * @param iterable<string,mixed> $values A list of key => value pairs for a multiple-set operation.
      * @param ?float $ttl Optional. The TTL value of this item.
      * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function setMultiple(array $values, ?float $ttl = null): PromiseInterface;
+    public function setMultiple(iterable $values, ?float $ttl = null): PromiseInterface;
 
     /**
      * Deletes multiple cache items in a single operation.
      *
-     * @param string[] $keys A list of string-based keys to be deleted.
+     * @param iterable<string> $keys A list of string-based keys to be deleted.
      * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function deleteMultiple(array $keys): PromiseInterface;
+    public function deleteMultiple(iterable $keys): PromiseInterface;
 
     /**
      * Wipes clean the entire cache.

--- a/tests/ArrayCacheTest.php
+++ b/tests/ArrayCacheTest.php
@@ -164,10 +164,34 @@ class ArrayCacheTest extends TestCase
             ->then($this->expectCallableOnceWith(['foo' => '1', 'bar' => 'baz']));
     }
 
+    public function testGetMultipleWithIterableKeysFromGenerator(): void
+    {
+        $this->cache = new ArrayCache();
+        $this->cache->set('foo', '1');
+
+        $keys = (function (): \Generator { yield from ['foo', 'bar']; })();
+
+        $this->cache
+            ->getMultiple($keys, 'baz')
+            ->then($this->expectCallableOnceWith(['foo' => '1', 'bar' => 'baz']));
+    }
+
     public function testSetMultiple(): void
     {
         $this->cache = new ArrayCache();
         $this->cache->setMultiple(['foo' => '1', 'bar' => '2'], 10);
+
+        $this->cache
+            ->getMultiple(['foo', 'bar'])
+            ->then($this->expectCallableOnceWith(['foo' => '1', 'bar' => '2']));
+    }
+
+    public function testSetMultipleWithIterableValuesFromGenerator(): void
+    {
+        $values = (function(): \Generator { yield from ['foo' => '1', 'bar' => '2']; })();
+
+        $this->cache = new ArrayCache();
+        $this->cache->setMultiple($values, 10);
 
         $this->cache
             ->getMultiple(['foo', 'bar'])
@@ -181,6 +205,30 @@ class ArrayCacheTest extends TestCase
 
         $this->cache
             ->deleteMultiple(['foo', 'baz'])
+            ->then($this->expectCallableOnceWith(true));
+
+        $this->cache
+            ->has('foo')
+            ->then($this->expectCallableOnceWith(false));
+
+        $this->cache
+            ->has('bar')
+            ->then($this->expectCallableOnceWith(true));
+
+        $this->cache
+            ->has('baz')
+            ->then($this->expectCallableOnceWith(false));
+    }
+
+    public function testDeleteMultipleWithIterableKeysFromGenerator(): void
+    {
+        $this->cache = new ArrayCache();
+        $this->cache->setMultiple(['foo' => 1, 'bar' => 2, 'baz' => 3]);
+
+        $keys = (function (): \Generator { yield from ['foo', 'baz']; })();
+
+        $this->cache
+            ->deleteMultiple($keys)
             ->then($this->expectCallableOnceWith(true));
 
         $this->cache


### PR DESCRIPTION
This changeset adds support for the `iterable` type for all methods working with multiple keys. This is done to bring the `CacheInterface` more in line with PSR-16 which also happens to support the `iterable` type (as originally suggested in #32).

* The `setMultiple()` method now accepts `iterable<string,mixed> $values` instead of `array<string,mixed>`. For consumers, passing an `array` continues to work like usual, but implementations of the `CacheInterface` may have to be adjusted to accept the `iterable` type.
* The `deleteMultiple()` method now accepts `iterable<string> $keys` instead of `string[]`. For consumers, passing an `array` continues to work like usual, but implementations of the `CacheInterface` may have to be adjusted to accept the `iterable` type.
* The `getMultiple()` method now accepts `iterable<string> $keys` instead of `string[]` and returns an `iterable<string,mixed>` instead of `array<string,mixed>`. For consumers, passing an `array` continues to work as usual, but implementations of `CacheInterface` may have to be adjusted to accept the `iterable` type.

Builds on top of #58, #60, #61 and #32
Refs https://github.com/reactphp/promise/pull/225, #30 and others