### PR TITLE
[1.x] Update test environment for PHP 7.2 to compatible PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "react/promise": "^3.0 || ^2.0 || ^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This changes ensures we can continue run PHPUnit on PHP 7.2 by updating PHPUnit to 8.5. This is due to recent improvements in composer as discussed in https://github.com/reactphp/event-loop/pull/284.